### PR TITLE
버그 개선사항 , 얼음 가스 광물 시세 기능 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
+# PR이 열린 상태(머지 대기)에서만 실행. dev에 직접 push/머지 시에는 실행하지 않음.
 on:
-    push:
-        branches: ["dev"]
     pull_request:
         branches: ["dev"]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+.cursor/debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/packages/master/src/discord/buildDiscordReplyPayload.js
+++ b/packages/master/src/discord/buildDiscordReplyPayload.js
@@ -1,10 +1,18 @@
 // packages/master/src/discord/buildDiscordReplyPayload.js
 export function buildDiscordReplyPayload(data) {
     if (data == null || typeof data !== "object") return { content: safeStringify(data) };
+    if (typeof data.error === "string" && data.error.trim())
+        return { content: `❌ ${data.error.trim()}` };
     if (data.embed !== true) {
         if (typeof data.message === "string" && data.message.trim())
             return { content: data.message };
         return { content: safeStringify(data) };
+    }
+
+    // 다중 임베드(페이지네이션): data.embeds 배열이 있으면 각 항목을 임베드로 빌드
+    if (Array.isArray(data.embeds) && data.embeds.length > 0) {
+        const embeds = data.embeds.slice(0, 10).map((spec) => buildOneEmbed(spec, data));
+        return { content: "", embeds };
     }
 
     const title = typeof data.title === "string" && data.title.trim() ? data.title : "result";
@@ -13,17 +21,7 @@ export function buildDiscordReplyPayload(data) {
             ? data.description
             : undefined;
 
-    const fields = Array.isArray(data.fields)
-        ? data.fields
-              .filter((f) => f && typeof f === "object")
-              .map((f) => ({
-                  name: String(f.name ?? "").trim() || " ",
-                  value: String(f.value ?? "").trim() || " ",
-                  inline: Boolean(f.inline),
-              }))
-              .filter((f) => f.name !== " " || f.value !== " ")
-        : [];
-
+    const fields = normalizeFields(data.fields);
     const footerText =
         typeof data.footer === "string" && data.footer.trim()
             ? data.footer
@@ -45,6 +43,53 @@ export function buildDiscordReplyPayload(data) {
     };
 
     return { content: "", embeds: [embed] };
+}
+
+/**
+ * @param {object} spec - { title?, description?, fields?, footer? }
+ * @param {object} fallback - 공통 footer 등 폴백용
+ */
+function buildOneEmbed(spec, fallback) {
+    const title =
+        typeof spec.title === "string" && spec.title.trim()
+            ? spec.title
+            : typeof fallback?.title === "string" && fallback.title.trim()
+              ? fallback.title
+              : "result";
+    const description =
+        typeof spec.description === "string" && spec.description.trim()
+            ? spec.description
+            : undefined;
+    const fields = normalizeFields(spec.fields);
+    const footerText =
+        typeof spec.footer === "string" && spec.footer.trim()
+            ? spec.footer
+            : typeof fallback?.footer === "string" && fallback.footer.trim()
+              ? fallback.footer
+              : "";
+    return {
+        title,
+        description,
+        fields: fields.length > 0 ? fields : [{ name: " ", value: " ", inline: false }],
+        footer: footerText ? { text: footerText } : undefined,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+const DISCORD_FIELD_VALUE_MAX = 1024;
+
+function normalizeFields(fields) {
+    if (!Array.isArray(fields)) return [];
+    return fields
+        .filter((f) => f && typeof f === "object")
+        .map((f) => {
+            const name = String(f.name ?? "").trim() || " ";
+            let value = String(f.value ?? "").trim() || " ";
+            if (value.length > DISCORD_FIELD_VALUE_MAX)
+                value = value.slice(0, DISCORD_FIELD_VALUE_MAX - 1) + "…";
+            return { name, value, inline: Boolean(f.inline) };
+        })
+        .filter((f) => f.name !== " " || f.value !== " ");
 }
 
 function safeStringify(v) {

--- a/packages/master/src/discord/commandRegistry.js
+++ b/packages/master/src/discord/commandRegistry.js
@@ -47,8 +47,8 @@ function pickComparableCommandFields(cmd) {
 }
 
 async function discordApi(method, path, body) {
-    const token = process.env.DISCORD_BOT_TOKEN;
-    if (!token) throw new Error("DISCORD_BOT_TOKEN이 없다");
+    const token = process.env.DISCORD_TOKEN;
+    if (!token) throw new Error("DISCORD_TOKEN이 없다");
 
     const url = `https://discord.com/api/v10${path}`;
     const res = await fetch(url, {

--- a/packages/master/src/discord/deployGuildCommands.js
+++ b/packages/master/src/discord/deployGuildCommands.js
@@ -86,7 +86,6 @@ function sha256Of(obj) {
 async function discordApi(method, path, body) {
     const token = process.env.DISCORD_TOKEN;
     if (!token) {
-        // 예상 가능한 설정 오류
         log.error("[commands] DISCORD_TOKEN이 없음");
         throw new Error("DISCORD_TOKEN이 없음");
     }

--- a/packages/master/src/initialize/startDevBridge.js
+++ b/packages/master/src/initialize/startDevBridge.js
@@ -59,7 +59,6 @@ export async function startDevBridge({ redis: redisFromCaller, signal } = {}) {
                 group: "bonsai-devmaster",
                 consumer: `devmaster-${process.pid}`,
                 onResult: async (resultEnv) => {
-                    // ✅ prod master가 result만 받도록 attribute로 type 지정
                     await publishJson(resultEnv, { type: "result" });
                     log.info(
                         `[devBridge] SNS(result) 발행 inReplyTo=${resultEnv.inReplyTo} ok=${resultEnv.ok}`

--- a/packages/master/src/initialize/startProdBridge.js
+++ b/packages/master/src/initialize/startProdBridge.js
@@ -6,6 +6,9 @@ import { buildDiscordReplyPayload } from "../discord/buildDiscordReplyPayload.js
 
 const log = logger();
 
+/** 채널 브로드캐스트 허용 길드(서버) ID. meta.guildId가 없거나 이 값과 일치할 때만 전송. (Key Vault 미포함, 코드 고정) */
+const DEFAULT_GUILD_ID = "1462083835306184872";
+
 /**
  * Prod Master 결과 수신기:
  * - Redis Streams(result) 소비 → pendingMap 매칭 → Discord editReply 종료
@@ -143,6 +146,15 @@ async function handleResult({ resultEnv, pendingMap, source }) {
     const channelId = String(meta.channelId ?? "").trim();
 
     if (broadcastToChannel && channelId) {
+        const guildId = String(meta.guildId ?? "").trim();
+        const allowedGuild = !guildId || guildId === DEFAULT_GUILD_ID;
+        if (!allowedGuild) {
+            log.warn("[prodBridge] 채널 브로드캐스트 스킵: guildId 불일치", {
+                guildId,
+                allowed: DEFAULT_GUILD_ID,
+            });
+            return true;
+        }
         const ok = Boolean(resultEnv?.ok);
         const data = resultEnv?.data ?? null;
         const token = String(process.env.DISCORD_TOKEN ?? "").trim();
@@ -166,10 +178,12 @@ async function handleResult({ resultEnv, pendingMap, source }) {
                 log.error("[prodBridge] 채널 브로드캐스트 실패", {
                     status: res.status,
                     body: text,
+                    channelId,
+                    guildId: guildId || DEFAULT_GUILD_ID,
                 });
             } else {
                 log.info(
-                    `[prodBridge] 채널 브로드캐스트 완료 source=${source} channelId=${channelId}`
+                    `[prodBridge] 채널 브로드캐스트 완료 source=${source} channelId=${channelId} guildId=${guildId || DEFAULT_GUILD_ID}`
                 );
             }
         } catch (err) {
@@ -249,8 +263,9 @@ function safeStringify(v) {
 }
 
 /**
- * SQS Body는 "원시 result envelope JSON"으로 온다.
- * 예: {"type":"result","inReplyTo":"...","ok":true,"data":...}
+ * SQS Body 파싱:
+ * - Raw 메시지: 직접 result envelope JSON → {"type":"result","inReplyTo":"...","data":...}
+ * - SNS 래퍼: Body가 SNS Notification이면 Message 필드 한 번 더 파싱해 result envelope 사용
  *
  * @param {string} body
  * @returns {{ok:true, resultEnv:any} | {ok:false, reason:string}}
@@ -266,7 +281,16 @@ function parseSqsBodyToResultEnvelope(body) {
         return { ok: false, reason: "body not json" };
     }
 
-    // 최소 계약만 확인 (type/result, inReplyTo)
+    // SNS가 래핑한 경우: Message 안에 result envelope 문자열이 있음
+    const snsMessage = typeof j?.Message === "string" ? j.Message.trim() : "";
+    if (String(j?.Type ?? "").trim() === "Notification" && snsMessage) {
+        try {
+            j = JSON.parse(snsMessage);
+        } catch {
+            return { ok: false, reason: "sns Message not json" };
+        }
+    }
+
     const type = String(j?.type ?? "").trim();
     const inReplyTo = String(j?.inReplyTo ?? "").trim();
 

--- a/packages/master/tests/buildDiscordReplyPayload.test.js
+++ b/packages/master/tests/buildDiscordReplyPayload.test.js
@@ -34,4 +34,31 @@ describe("master/buildDiscordReplyPayload", () => {
         expect(p.content).toBe("");
         expect(p.embeds[0].fields.length).toBeGreaterThan(0);
     });
+
+    test("embed=true + embeds 배열이 있으면 다중 임베드로 반환", () => {
+        const p = buildDiscordReplyPayload({
+            embed: true,
+            footer: "공통 푸터",
+            embeds: [
+                {
+                    title: "페이지 1",
+                    fields: [
+                        { name: "품목", value: "A\nB", inline: true },
+                        { name: "시세", value: "1\n2", inline: true },
+                    ],
+                },
+                {
+                    title: "페이지 2",
+                    fields: [{ name: "품목", value: "C", inline: true }],
+                },
+            ],
+        });
+        expect(p.content).toBe("");
+        expect(p.embeds).toHaveLength(2);
+        expect(p.embeds[0].title).toBe("페이지 1");
+        expect(p.embeds[0].fields).toHaveLength(2);
+        expect(p.embeds[0].footer).toEqual({ text: "공통 푸터" });
+        expect(p.embeds[1].title).toBe("페이지 2");
+        expect(p.embeds[1].fields).toHaveLength(1);
+    });
 });

--- a/packages/shared/src/db/getPrisma.js
+++ b/packages/shared/src/db/getPrisma.js
@@ -15,33 +15,6 @@ function getTenantDbUrlTemplate() {
 }
 const TENANT_DB_NAME_PREFIX = String(process.env.TENANT_DB_NAME_PREFIX ?? "bonsai_").trim();
 
-// #region agent log
-queueMicrotask(() => {
-    const hasT = Boolean(process.env.TENANT_DB_URL_TEMPLATE?.trim());
-    const hasD = Boolean(process.env.DATABASE_URL?.trim());
-    fetch("http://127.0.0.1:7242/ingest/7070e61a-5c08-41bb-b8db-31b1f8c2675e", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-            location: "getPrisma.js:moduleLoad",
-            message: "getPrisma module load: env at load time",
-            data: {
-                runMode: process.env.RUN_MODE ?? "(undefined)",
-                tenant: process.env.TENANT ?? "(undefined)",
-                hasTenantDbUrlTemplate: hasT,
-                hasDatabaseUrl: hasD,
-                templateNowLength: getTenantDbUrlTemplate().length,
-                templateNowEmpty: getTenantDbUrlTemplate() === "",
-            },
-            timestamp: Date.now(),
-            sessionId: "debug-session",
-            runId: "post-fix",
-            hypothesisId: "A",
-        }),
-    }).catch(() => {});
-});
-// #endregion
-
 export function sanitizeTenantKey(key) {
     return String(key ?? "").replace(/[^a-zA-Z0-9_-]/g, "");
 }
@@ -53,26 +26,6 @@ export function buildTenantDbUrl(tenantKey) {
     const safe = sanitizeTenantKey(tenantKey);
     if (!safe) throw new Error("tenantKey가 비어있거나 유효하지 않습니다.");
     const template = getTenantDbUrlTemplate();
-    // #region agent log
-    fetch("http://127.0.0.1:7242/ingest/7070e61a-5c08-41bb-b8db-31b1f8c2675e", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-            location: "getPrisma.js:buildTenantDbUrl",
-            message: "buildTenantDbUrl called",
-            data: {
-                templateEmpty: template === "",
-                templateLength: template.length,
-                processEnvHasTemplate: Boolean(process.env.TENANT_DB_URL_TEMPLATE?.trim()),
-                processEnvHasDatabaseUrl: Boolean(process.env.DATABASE_URL?.trim()),
-            },
-            timestamp: Date.now(),
-            sessionId: "debug-session",
-            runId: "post-fix",
-            hypothesisId: "E",
-        }),
-    }).catch(() => {});
-    // #endregion
     if (template && template.includes("%s")) {
         return template.replace("%s", safe);
     }

--- a/packages/worker/src/commands/esiComplete.js
+++ b/packages/worker/src/commands/esiComplete.js
@@ -157,6 +157,7 @@ export default {
             meta: {
                 broadcastToChannel: true,
                 channelId,
+                guildId: String(meta.guildId ?? "").trim(),
             },
         };
     },

--- a/packages/worker/src/commands/gasPrice.js
+++ b/packages/worker/src/commands/gasPrice.js
@@ -1,0 +1,204 @@
+// packages/worker/src/commands/gasPrice.js
+import { logger } from "@bonsai/shared";
+import { FULLERITE_ITEMS, HUBS } from "../market/constants.js";
+import { getMarketPrice, getRegionHistory } from "../market/esiMarketCache.js";
+
+const log = logger();
+
+function fmtIsk(n) {
+    if (n == null || !Number.isFinite(n)) return "—";
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return Math.round(n).toLocaleString();
+}
+
+function fmtPct(p) {
+    if (p == null || !Number.isFinite(p)) return "—";
+    return `${p >= 0 ? "+" : ""}${p.toFixed(1)}%`;
+}
+
+export default {
+    name: "가스시세",
+    discord: {
+        name: "가스시세",
+        description: "웜홀 가스(Fullerite 9종) 시세 (Jita/Amarr)",
+        type: 1,
+        options: [],
+    },
+
+    /**
+     * @param {object} ctx
+     * @param {import("redis").RedisClientType} ctx.redis
+     * @param {string} ctx.tenantKey
+     * @param {any} envelope
+     * @returns {Promise<{ok:boolean, data:any}>}
+     */
+    async execute(ctx, _envelope) {
+        const redis = ctx?.redis;
+        const tenantKey = String(ctx?.tenantKey ?? "").trim();
+        if (!redis || !tenantKey) {
+            return { ok: false, data: { error: "시스템 설정 오류" } };
+        }
+
+        const itemCount = FULLERITE_ITEMS.length;
+        log.info("[cmd:가스시세] 시세 조회 시작", { tenant: tenantKey, items: itemCount });
+
+        const rowPromises = FULLERITE_ITEMS.map(async (item) => {
+            try {
+                const [jita, amarr, histJita, histAmarr] = await Promise.all([
+                    getMarketPrice(redis, { tenantKey, hub: "jita", typeId: item.typeId }),
+                    getMarketPrice(redis, { tenantKey, hub: "amarr", typeId: item.typeId }),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.jita.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.amarr.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                ]);
+                const jitaSell = jita.sellMin;
+                const amarrSell = amarr.sellMin;
+                const delta = jitaSell != null && amarrSell != null ? amarrSell - jitaSell : null;
+                const deltaPct =
+                    jitaSell != null && jitaSell !== 0 && delta != null
+                        ? (delta / jitaSell) * 100
+                        : null;
+                const iskPerM3 =
+                    jitaSell != null && item.volume > 0 ? jitaSell / item.volume : null;
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell,
+                    jitaBuy: jita.buyMax,
+                    amarrSell,
+                    amarrBuy: amarr.buyMax,
+                    jitaCapped: jita.capped ?? false,
+                    amarrCapped: amarr.capped ?? false,
+                    delta,
+                    deltaPct,
+                    iskPerM3,
+                    regionAvg1dJita: histJita?.regionAvg1d ?? null,
+                    regionAvg1dAmarr: histAmarr?.regionAvg1d ?? null,
+                    hasStale: jita.stale || amarr.stale,
+                };
+            } catch (err) {
+                log.warn(`[cmd:가스시세] typeId=${item.typeId} err=${err?.message}`);
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell: null,
+                    jitaBuy: null,
+                    amarrSell: null,
+                    amarrBuy: null,
+                    jitaCapped: false,
+                    amarrCapped: false,
+                    delta: null,
+                    deltaPct: null,
+                    iskPerM3: null,
+                    regionAvg1dJita: null,
+                    regionAvg1dAmarr: null,
+                    error: err?.message,
+                    hasStale: false,
+                };
+            }
+        });
+        const rows = await Promise.all(rowPromises);
+        const hasStale = rows.some((r) => r.hasStale);
+        const errorCount = rows.filter((r) => r.error).length;
+        for (const r of rows) delete r.hasStale;
+
+        const hasAnyPrice = rows.some((r) => r.jitaSell != null || r.amarrSell != null);
+        const noData = rows.length === 0 || errorCount === rows.length || !hasAnyPrice;
+
+        log.info("[cmd:가스시세] 시세 수집 완료", {
+            tenant: tenantKey,
+            rows: rows.length,
+            errors: errorCount,
+            stale: hasStale,
+            noData,
+        });
+
+        if (noData) {
+            const msg =
+                errorCount === rows.length && rows.length > 0
+                    ? `시세 조회 실패 (모든 품목 오류, ${errorCount}건). ESI/네트워크 확인 후 재시도해 주세요.`
+                    : "시세 데이터를 가져오지 못했습니다.";
+            log.warn("[cmd:가스시세] 반환: 오류 (데이터 없음)", {
+                tenant: tenantKey,
+                errorCount,
+                rows: rows.length,
+            });
+            return {
+                ok: false,
+                data: { error: msg },
+            };
+        }
+
+        rows.sort((a, b) => (b.iskPerM3 ?? 0) - (a.iskPerM3 ?? 0));
+
+        const ITEMS_PER_PAGE = 10;
+        const footer = hasStale ? "일부 데이터는 캐시(stale)입니다." : "ESI 기준, 1시간 캐시";
+        const baseTitle = "웜홀 가스 시세 (Fullerite)";
+        const baseDescription = "Jita/Amarr 스테이션 S/B · Δ(Amarr−Jita)% · ISK/m³ (내림차순)";
+
+        const embeds = [];
+        for (let p = 0; p < rows.length; p += ITEMS_PER_PAGE) {
+            const chunk = rows.slice(p, p + ITEMS_PER_PAGE);
+            const names = chunk.map((r) => {
+                const label = r.name != null && String(r.name).trim() ? r.name : `타입 ${r.typeId}`;
+                return r.error ? `${label} — 오류` : label;
+            });
+            const jitaAmarr = chunk.map((r) => {
+                if (r.error) return "—";
+                const j = `${fmtIsk(r.jitaSell)}/${fmtIsk(r.jitaBuy)}${r.jitaCapped ? " (cap)" : ""}`;
+                const a = `${fmtIsk(r.amarrSell)}/${fmtIsk(r.amarrBuy)}${r.amarrCapped ? " (cap)" : ""}`;
+                return `${j} ${a}`;
+            });
+            const deltaM3 = chunk.map((r) => {
+                if (r.error) return "—";
+                const d = r.deltaPct != null ? fmtPct(r.deltaPct) : "—";
+                const m3 = r.iskPerM3 != null ? fmtIsk(r.iskPerM3) : "—";
+                return `${d} · ${m3}`;
+            });
+            const pageNum = Math.floor(p / ITEMS_PER_PAGE) + 1;
+            const totalPages = Math.ceil(rows.length / ITEMS_PER_PAGE);
+            const title = totalPages > 1 ? `${baseTitle} (${pageNum}/${totalPages})` : baseTitle;
+            embeds.push({
+                title,
+                description: p === 0 ? baseDescription : undefined,
+                fields: [
+                    { name: "품목", value: names.join("\n") || "—", inline: true },
+                    { name: "Jita/Amarr (S/B)", value: jitaAmarr.join("\n") || "—", inline: true },
+                    { name: "Δ% · ISK/m³", value: deltaM3.join("\n") || "—", inline: true },
+                ],
+                footer,
+            });
+        }
+
+        log.info("[cmd:가스시세] 응답 반환 완료", {
+            tenant: tenantKey,
+            embedPages: embeds.length,
+            stale: hasStale,
+        });
+
+        return {
+            ok: true,
+            data: {
+                embed: true,
+                embeds: embeds.length ? embeds : undefined,
+                title: baseTitle,
+                description: baseDescription,
+                fields:
+                    embeds.length === 0
+                        ? [{ name: "시세", value: "조회 실패", inline: false }]
+                        : undefined,
+                footer,
+            },
+        };
+    },
+};

--- a/packages/worker/src/commands/icePrice.js
+++ b/packages/worker/src/commands/icePrice.js
@@ -1,0 +1,204 @@
+// packages/worker/src/commands/icePrice.js
+import { logger } from "@bonsai/shared";
+import { HUBS, ICE_ITEMS } from "../market/constants.js";
+import { getMarketPrice, getRegionHistory } from "../market/esiMarketCache.js";
+
+const log = logger();
+
+function fmtIsk(n) {
+    if (n == null || !Number.isFinite(n)) return "—";
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return Math.round(n).toLocaleString();
+}
+
+function fmtPct(p) {
+    if (p == null || !Number.isFinite(p)) return "—";
+    return `${p >= 0 ? "+" : ""}${p.toFixed(1)}%`;
+}
+
+export default {
+    name: "얼음시세",
+    discord: {
+        name: "얼음시세",
+        description: "아이스 산출물 7종 시세 (Jita/Amarr)",
+        type: 1,
+        options: [],
+    },
+
+    /**
+     * @param {object} ctx
+     * @param {import("redis").RedisClientType} ctx.redis
+     * @param {string} ctx.tenantKey
+     * @param {any} envelope
+     * @returns {Promise<{ok:boolean, data:any}>}
+     */
+    async execute(ctx, _envelope) {
+        const redis = ctx?.redis;
+        const tenantKey = String(ctx?.tenantKey ?? "").trim();
+        if (!redis || !tenantKey) {
+            return { ok: false, data: { error: "시스템 설정 오류" } };
+        }
+
+        const itemCount = ICE_ITEMS.length;
+        log.info("[cmd:얼음시세] 시세 조회 시작", { tenant: tenantKey, items: itemCount });
+
+        const rowPromises = ICE_ITEMS.map(async (item) => {
+            try {
+                const [jita, amarr, histJita, histAmarr] = await Promise.all([
+                    getMarketPrice(redis, { tenantKey, hub: "jita", typeId: item.typeId }),
+                    getMarketPrice(redis, { tenantKey, hub: "amarr", typeId: item.typeId }),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.jita.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.amarr.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                ]);
+                const jitaSell = jita.sellMin;
+                const amarrSell = amarr.sellMin;
+                const delta = jitaSell != null && amarrSell != null ? amarrSell - jitaSell : null;
+                const deltaPct =
+                    jitaSell != null && jitaSell !== 0 && delta != null
+                        ? (delta / jitaSell) * 100
+                        : null;
+                const iskPerM3 =
+                    jitaSell != null && item.volume > 0 ? jitaSell / item.volume : null;
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell,
+                    jitaBuy: jita.buyMax,
+                    amarrSell,
+                    amarrBuy: amarr.buyMax,
+                    jitaCapped: jita.capped ?? false,
+                    amarrCapped: amarr.capped ?? false,
+                    delta,
+                    deltaPct,
+                    iskPerM3,
+                    regionAvg1dJita: histJita?.regionAvg1d ?? null,
+                    regionAvg1dAmarr: histAmarr?.regionAvg1d ?? null,
+                    hasStale: jita.stale || amarr.stale,
+                };
+            } catch (err) {
+                log.warn(`[cmd:얼음시세] typeId=${item.typeId} err=${err?.message}`);
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell: null,
+                    jitaBuy: null,
+                    amarrSell: null,
+                    amarrBuy: null,
+                    jitaCapped: false,
+                    amarrCapped: false,
+                    delta: null,
+                    deltaPct: null,
+                    iskPerM3: null,
+                    regionAvg1dJita: null,
+                    regionAvg1dAmarr: null,
+                    error: err?.message,
+                    hasStale: false,
+                };
+            }
+        });
+        const rows = await Promise.all(rowPromises);
+        const hasStale = rows.some((r) => r.hasStale);
+        const errorCount = rows.filter((r) => r.error).length;
+        for (const r of rows) delete r.hasStale;
+
+        const hasAnyPrice = rows.some((r) => r.jitaSell != null || r.amarrSell != null);
+        const noData = rows.length === 0 || errorCount === rows.length || !hasAnyPrice;
+
+        log.info("[cmd:얼음시세] 시세 수집 완료", {
+            tenant: tenantKey,
+            rows: rows.length,
+            errors: errorCount,
+            stale: hasStale,
+            noData,
+        });
+
+        if (noData) {
+            const msg =
+                errorCount === rows.length && rows.length > 0
+                    ? `시세 조회 실패 (모든 품목 오류, ${errorCount}건). ESI/네트워크 확인 후 재시도해 주세요.`
+                    : "시세 데이터를 가져오지 못했습니다.";
+            log.warn("[cmd:얼음시세] 반환: 오류 (데이터 없음)", {
+                tenant: tenantKey,
+                errorCount,
+                rows: rows.length,
+            });
+            return {
+                ok: false,
+                data: { error: msg },
+            };
+        }
+
+        rows.sort((a, b) => (b.iskPerM3 ?? 0) - (a.iskPerM3 ?? 0));
+
+        const ITEMS_PER_PAGE = 10;
+        const footer = hasStale ? "일부 데이터는 캐시(stale)입니다." : "ESI 기준, 1시간 캐시";
+        const baseTitle = "얼음 시세 (아이스 산출물 7종)";
+        const baseDescription = "Jita/Amarr 스테이션 S/B · Δ(Amarr−Jita)% · ISK/m³ (내림차순)";
+
+        const embeds = [];
+        for (let p = 0; p < rows.length; p += ITEMS_PER_PAGE) {
+            const chunk = rows.slice(p, p + ITEMS_PER_PAGE);
+            const names = chunk.map((r) => {
+                const label = r.name != null && String(r.name).trim() ? r.name : `타입 ${r.typeId}`;
+                return r.error ? `${label} — 오류` : label;
+            });
+            const jitaAmarr = chunk.map((r) => {
+                if (r.error) return "—";
+                const j = `${fmtIsk(r.jitaSell)}/${fmtIsk(r.jitaBuy)}${r.jitaCapped ? " (cap)" : ""}`;
+                const a = `${fmtIsk(r.amarrSell)}/${fmtIsk(r.amarrBuy)}${r.amarrCapped ? " (cap)" : ""}`;
+                return `${j} ${a}`;
+            });
+            const deltaM3 = chunk.map((r) => {
+                if (r.error) return "—";
+                const d = r.deltaPct != null ? fmtPct(r.deltaPct) : "—";
+                const m3 = r.iskPerM3 != null ? fmtIsk(r.iskPerM3) : "—";
+                return `${d} · ${m3}`;
+            });
+            const pageNum = Math.floor(p / ITEMS_PER_PAGE) + 1;
+            const totalPages = Math.ceil(rows.length / ITEMS_PER_PAGE);
+            const title = totalPages > 1 ? `${baseTitle} (${pageNum}/${totalPages})` : baseTitle;
+            embeds.push({
+                title,
+                description: p === 0 ? baseDescription : undefined,
+                fields: [
+                    { name: "품목", value: names.join("\n") || "—", inline: true },
+                    { name: "Jita/Amarr (S/B)", value: jitaAmarr.join("\n") || "—", inline: true },
+                    { name: "Δ% · ISK/m³", value: deltaM3.join("\n") || "—", inline: true },
+                ],
+                footer,
+            });
+        }
+
+        log.info("[cmd:얼음시세] 응답 반환 완료", {
+            tenant: tenantKey,
+            embedPages: embeds.length,
+            stale: hasStale,
+        });
+
+        return {
+            ok: true,
+            data: {
+                embed: true,
+                embeds: embeds.length ? embeds : undefined,
+                title: baseTitle,
+                description: baseDescription,
+                fields:
+                    embeds.length === 0
+                        ? [{ name: "시세", value: "조회 실패", inline: false }]
+                        : undefined,
+                footer,
+            },
+        };
+    },
+};

--- a/packages/worker/src/commands/index.js
+++ b/packages/worker/src/commands/index.js
@@ -3,10 +3,13 @@ import dev from "./dev.js";
 import esiComplete from "./esiComplete.js";
 import esiList from "./esiList.js";
 import esiSignup from "./esiSignup.js";
+import gasPrice from "./gasPrice.js";
+import icePrice from "./icePrice.js";
+import mineralPrice from "./mineralPrice.js";
 import ping from "./ping.js";
 
 export function getCommandDefinitions() {
-    return [ping, dev, esiSignup, esiComplete, esiList];
+    return [ping, dev, esiSignup, esiComplete, esiList, gasPrice, icePrice, mineralPrice];
 }
 
 export function getDiscordSchemas() {

--- a/packages/worker/src/commands/mineralPrice.js
+++ b/packages/worker/src/commands/mineralPrice.js
@@ -1,0 +1,204 @@
+// packages/worker/src/commands/mineralPrice.js
+import { logger } from "@bonsai/shared";
+import { HUBS, MINERAL_ITEMS } from "../market/constants.js";
+import { getMarketPrice, getRegionHistory } from "../market/esiMarketCache.js";
+
+const log = logger();
+
+function fmtIsk(n) {
+    if (n == null || !Number.isFinite(n)) return "—";
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return Math.round(n).toLocaleString();
+}
+
+function fmtPct(p) {
+    if (p == null || !Number.isFinite(p)) return "—";
+    return `${p >= 0 ? "+" : ""}${p.toFixed(1)}%`;
+}
+
+export default {
+    name: "광물시세",
+    discord: {
+        name: "광물시세",
+        description: "기본 오어 12종 시세 (Jita/Amarr)",
+        type: 1,
+        options: [],
+    },
+
+    /**
+     * @param {object} ctx
+     * @param {import("redis").RedisClientType} ctx.redis
+     * @param {string} ctx.tenantKey
+     * @param {any} envelope
+     * @returns {Promise<{ok:boolean, data:any}>}
+     */
+    async execute(ctx, _envelope) {
+        const redis = ctx?.redis;
+        const tenantKey = String(ctx?.tenantKey ?? "").trim();
+        if (!redis || !tenantKey) {
+            return { ok: false, data: { error: "시스템 설정 오류" } };
+        }
+
+        const itemCount = MINERAL_ITEMS.length;
+        log.info("[cmd:광물시세] 시세 조회 시작", { tenant: tenantKey, items: itemCount });
+
+        const rowPromises = MINERAL_ITEMS.map(async (item) => {
+            try {
+                const [jita, amarr, histJita, histAmarr] = await Promise.all([
+                    getMarketPrice(redis, { tenantKey, hub: "jita", typeId: item.typeId }),
+                    getMarketPrice(redis, { tenantKey, hub: "amarr", typeId: item.typeId }),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.jita.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                    getRegionHistory(redis, {
+                        tenantKey,
+                        regionId: HUBS.amarr.regionId,
+                        typeId: item.typeId,
+                    }).catch(() => ({ regionAvg1d: null, regionAvg7d: null })),
+                ]);
+                const jitaSell = jita.sellMin;
+                const amarrSell = amarr.sellMin;
+                const delta = jitaSell != null && amarrSell != null ? amarrSell - jitaSell : null;
+                const deltaPct =
+                    jitaSell != null && jitaSell !== 0 && delta != null
+                        ? (delta / jitaSell) * 100
+                        : null;
+                const iskPerM3 =
+                    jitaSell != null && item.volume > 0 ? jitaSell / item.volume : null;
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell,
+                    jitaBuy: jita.buyMax,
+                    amarrSell,
+                    amarrBuy: amarr.buyMax,
+                    jitaCapped: jita.capped ?? false,
+                    amarrCapped: amarr.capped ?? false,
+                    delta,
+                    deltaPct,
+                    iskPerM3,
+                    regionAvg1dJita: histJita?.regionAvg1d ?? null,
+                    regionAvg1dAmarr: histAmarr?.regionAvg1d ?? null,
+                    hasStale: jita.stale || amarr.stale,
+                };
+            } catch (err) {
+                log.warn(`[cmd:광물시세] typeId=${item.typeId} err=${err?.message}`);
+                return {
+                    name: item.name,
+                    typeId: item.typeId,
+                    volume: item.volume,
+                    jitaSell: null,
+                    jitaBuy: null,
+                    amarrSell: null,
+                    amarrBuy: null,
+                    jitaCapped: false,
+                    amarrCapped: false,
+                    delta: null,
+                    deltaPct: null,
+                    iskPerM3: null,
+                    regionAvg1dJita: null,
+                    regionAvg1dAmarr: null,
+                    error: err?.message,
+                    hasStale: false,
+                };
+            }
+        });
+        const rows = await Promise.all(rowPromises);
+        const hasStale = rows.some((r) => r.hasStale);
+        const errorCount = rows.filter((r) => r.error).length;
+        for (const r of rows) delete r.hasStale;
+
+        const hasAnyPrice = rows.some((r) => r.jitaSell != null || r.amarrSell != null);
+        const noData = rows.length === 0 || errorCount === rows.length || !hasAnyPrice;
+
+        log.info("[cmd:광물시세] 시세 수집 완료", {
+            tenant: tenantKey,
+            rows: rows.length,
+            errors: errorCount,
+            stale: hasStale,
+            noData,
+        });
+
+        if (noData) {
+            const msg =
+                errorCount === rows.length && rows.length > 0
+                    ? `시세 조회 실패 (모든 품목 오류, ${errorCount}건). ESI/네트워크 확인 후 재시도해 주세요.`
+                    : "시세 데이터를 가져오지 못했습니다.";
+            log.warn("[cmd:광물시세] 반환: 오류 (데이터 없음)", {
+                tenant: tenantKey,
+                errorCount,
+                rows: rows.length,
+            });
+            return {
+                ok: false,
+                data: { error: msg },
+            };
+        }
+
+        rows.sort((a, b) => (b.iskPerM3 ?? 0) - (a.iskPerM3 ?? 0));
+
+        const ITEMS_PER_PAGE = 10;
+        const footer = hasStale ? "일부 데이터는 캐시(stale)입니다." : "ESI 기준, 1시간 캐시";
+        const baseTitle = "광물 시세 (기본 오어 12종)";
+        const baseDescription = "Jita/Amarr 스테이션 S/B · Δ(Amarr−Jita)% · ISK/m³";
+
+        const embeds = [];
+        for (let p = 0; p < rows.length; p += ITEMS_PER_PAGE) {
+            const chunk = rows.slice(p, p + ITEMS_PER_PAGE);
+            const names = chunk.map((r) => {
+                const label = r.name != null && String(r.name).trim() ? r.name : `타입 ${r.typeId}`;
+                return r.error ? `${label} — 오류` : label;
+            });
+            const jitaAmarr = chunk.map((r) => {
+                if (r.error) return "—";
+                const j = `${fmtIsk(r.jitaSell)}/${fmtIsk(r.jitaBuy)}${r.jitaCapped ? " (cap)" : ""}`;
+                const a = `${fmtIsk(r.amarrSell)}/${fmtIsk(r.amarrBuy)}${r.amarrCapped ? " (cap)" : ""}`;
+                return `${j} ${a}`;
+            });
+            const deltaM3 = chunk.map((r) => {
+                if (r.error) return "—";
+                const d = r.deltaPct != null ? fmtPct(r.deltaPct) : "—";
+                const m3 = r.iskPerM3 != null ? fmtIsk(r.iskPerM3) : "—";
+                return `${d} · ${m3}`;
+            });
+            const pageNum = Math.floor(p / ITEMS_PER_PAGE) + 1;
+            const totalPages = Math.ceil(rows.length / ITEMS_PER_PAGE);
+            const title = totalPages > 1 ? `${baseTitle} (${pageNum}/${totalPages})` : baseTitle;
+            embeds.push({
+                title,
+                description: p === 0 ? baseDescription : undefined,
+                fields: [
+                    { name: "품목", value: names.join("\n") || "—", inline: true },
+                    { name: "Jita/Amarr (S/B)", value: jitaAmarr.join("\n") || "—", inline: true },
+                    { name: "Δ% · ISK/m³", value: deltaM3.join("\n") || "—", inline: true },
+                ],
+                footer,
+            });
+        }
+
+        log.info("[cmd:광물시세] 응답 반환 완료", {
+            tenant: tenantKey,
+            embedPages: embeds.length,
+            stale: hasStale,
+        });
+
+        return {
+            ok: true,
+            data: {
+                embed: true,
+                embeds: embeds.length ? embeds : undefined,
+                title: baseTitle,
+                description: baseDescription,
+                fields:
+                    embeds.length === 0
+                        ? [{ name: "시세", value: "조회 실패", inline: false }]
+                        : undefined,
+                footer,
+            },
+        };
+    },
+};

--- a/packages/worker/src/market/constants.js
+++ b/packages/worker/src/market/constants.js
@@ -1,0 +1,50 @@
+/**
+ * 마켓 시세 조회용 상수: 허브, Fullerite 9종, 기본 오어 12종, 아이스 산출물 7종.
+ * 표시명은 모두 코드 고정 (한글 로컬/캐시 미사용).
+ */
+
+/** Jita / Amarr region_id, station_id */
+export const HUBS = Object.freeze({
+    jita: { regionId: 10000002, stationId: 60003760, label: "Jita" },
+    amarr: { regionId: 10000043, stationId: 60008494, label: "Amarr" },
+});
+
+/** Fullerite 9종 (웜홀 가스). typeId 30370~30378, 표시명·volume 고정 */
+export const FULLERITE_ITEMS = Object.freeze([
+    { typeId: 30370, name: "Fullerite-C50", volume: 1 },
+    { typeId: 30371, name: "Fullerite-C60", volume: 1 },
+    { typeId: 30372, name: "Fullerite-C70", volume: 1 },
+    { typeId: 30373, name: "Fullerite-C72", volume: 1 },
+    { typeId: 30374, name: "Fullerite-C84", volume: 2 },
+    { typeId: 30375, name: "Fullerite-C28", volume: 2 },
+    { typeId: 30376, name: "Fullerite-C32", volume: 5 },
+    { typeId: 30377, name: "Fullerite-C320", volume: 5 },
+    { typeId: 30378, name: "Fullerite-C540", volume: 10 },
+]);
+
+/** 기본 오어 12종 (변종 오어 제외). 표시명·volume 고정 */
+export const MINERAL_ITEMS = Object.freeze([
+    { typeId: 22, name: "Arkonor", volume: 16 },
+    { typeId: 19, name: "Spodumain", volume: 16 },
+    { typeId: 18, name: "Plagioclase", volume: 0.35 },
+    { typeId: 1223, name: "Bistot", volume: 16 },
+    { typeId: 1225, name: "Crokite", volume: 8 },
+    { typeId: 1226, name: "Jaspet", volume: 2 },
+    { typeId: 1227, name: "Omber", volume: 0.6 },
+    { typeId: 1228, name: "Scordite", volume: 0.15 },
+    { typeId: 1229, name: "Gneiss", volume: 16 },
+    { typeId: 1230, name: "Veldspar", volume: 0.1 },
+    { typeId: 1232, name: "Dark Ochre", volume: 8 },
+    { typeId: 11396, name: "Mercoxit", volume: 40 },
+]);
+
+/** 아이스 산출물 7종. 표시명·volume 고정 */
+export const ICE_ITEMS = Object.freeze([
+    { typeId: 16272, name: "Heavy Water", volume: 1 },
+    { typeId: 16273, name: "Liquid Ozone", volume: 1 },
+    { typeId: 16274, name: "Helium Isotopes", volume: 1 },
+    { typeId: 16275, name: "Strontium Clathrates", volume: 1 },
+    { typeId: 17889, name: "Hydrogen Isotopes", volume: 1 },
+    { typeId: 17888, name: "Nitrogen Isotopes", volume: 1 },
+    { typeId: 17887, name: "Oxygen Isotopes", volume: 1 },
+]);

--- a/packages/worker/src/market/esiMarketCache.js
+++ b/packages/worker/src/market/esiMarketCache.js
@@ -1,0 +1,274 @@
+/**
+ * ESI 마켓 오더 조회 + Redis 캐시(TTL 3600) + per-key 락.
+ * 리전 히스토리(평균가) 캐시 TTL 6h.
+ * 캐시 키: mkt:{tenantKey}:esi:v1:{hub}:{typeId}
+ * 히스토리: mkt:{tenantKey}:esi:history:v1:{regionId}:{typeId}
+ * 동시성: ESI 호출 동시 4~6개로 제한(429 방어).
+ */
+import { HUBS } from "./constants.js";
+
+const ESI_BASE = "https://esi.evetech.net/latest";
+const CACHE_TTL_SEC = 3600;
+const HISTORY_CACHE_TTL_SEC = 6 * 3600; // 6h
+const LOCK_TTL_SEC = 30;
+const LOCK_BACKOFF_MS = 500;
+const LOCK_RETRIES = 6;
+
+/** orders 페이지네이션: 최대 페이지 수(정확도-비용 트레이드오프) */
+const PAGE_CAP = 10;
+/** 스테이션 오더 1건이라도 발견 후 추가로 볼 페이지 수(조기 종료) */
+const EXTRA_PAGES_AFTER_HIT = 2;
+/** 동시 ESI 요청 수 제한(429 방어) */
+const ESI_CONCURRENCY = 5;
+
+/** 동시 실행 수 제한용 큐 */
+const esiQueue = [];
+let esiRunning = 0;
+
+function runWithLimit(fn) {
+    return new Promise((resolve, reject) => {
+        const run = () => {
+            esiRunning++;
+            Promise.resolve(fn())
+                .then(resolve, reject)
+                .finally(() => {
+                    esiRunning--;
+                    if (esiQueue.length > 0) esiQueue.shift()();
+                });
+        };
+        if (esiRunning < ESI_CONCURRENCY) run();
+        else esiQueue.push(run);
+    });
+}
+
+/**
+ * @param {import("redis").RedisClientType} redis
+ * @param {{ tenantKey: string, hub: "jita"|"amarr", typeId: number }} opts
+ * @returns {Promise<{ fetchedAt: number, sellMin: number|null, buyMax: number|null, regionId: number, stationId: number, typeId: number, stale?: boolean, capped?: boolean }>}
+ */
+export async function getMarketPrice(redis, { tenantKey, hub, typeId }) {
+    const tenant = String(tenantKey ?? "").trim();
+    const hubKey = hub === "amarr" ? "amarr" : "jita";
+    const hubInfo = HUBS[hubKey];
+    const cacheKey = `mkt:${tenant}:esi:v1:${hubKey}:${typeId}`;
+    const lockKey = `mkt:${tenant}:esi:lock:${hubKey}:${typeId}`;
+
+    const cached = await redis.get(cacheKey);
+    if (cached) {
+        try {
+            const data = JSON.parse(cached);
+            return {
+                fetchedAt: data.fetchedAt,
+                sellMin: data.sellMin ?? null,
+                buyMax: data.buyMax ?? null,
+                regionId: hubInfo.regionId,
+                stationId: hubInfo.stationId,
+                typeId: data.typeId ?? typeId,
+                ...(data.capped && { capped: true }),
+            };
+        } catch {
+            // invalid JSON, fall through to fetch
+        }
+    }
+
+    let lockAcquired = false;
+    for (let i = 0; i < LOCK_RETRIES; i++) {
+        const ok = await redis.set(lockKey, "1", { NX: true, EX: LOCK_TTL_SEC });
+        if (ok) {
+            lockAcquired = true;
+            break;
+        }
+        await sleep(LOCK_BACKOFF_MS * (i + 1));
+        const recheck = await redis.get(cacheKey);
+        if (recheck) {
+            const data = JSON.parse(recheck);
+            return {
+                fetchedAt: data.fetchedAt,
+                sellMin: data.sellMin ?? null,
+                buyMax: data.buyMax ?? null,
+                regionId: hubInfo.regionId,
+                stationId: hubInfo.stationId,
+                typeId: data.typeId ?? typeId,
+                ...(data.capped && { capped: true }),
+            };
+        }
+    }
+
+    if (!lockAcquired) {
+        const stale = await redis.get(cacheKey);
+        if (stale) {
+            const data = JSON.parse(stale);
+            return {
+                fetchedAt: data.fetchedAt,
+                sellMin: data.sellMin ?? null,
+                buyMax: data.buyMax ?? null,
+                regionId: hubInfo.regionId,
+                stationId: hubInfo.stationId,
+                typeId: data.typeId ?? typeId,
+                stale: true,
+                ...(data.capped && { capped: true }),
+            };
+        }
+        throw new Error("시세 조회가 지연 중입니다. 잠시 후 다시 시도해 주세요.");
+    }
+
+    try {
+        const { sellMin, buyMax, capped } = await runWithLimit(() =>
+            fetchStationOrders(hubInfo.regionId, hubInfo.stationId, typeId)
+        );
+        const value = {
+            fetchedAt: Math.floor(Date.now() / 1000),
+            sellMin,
+            buyMax,
+            regionId: hubInfo.regionId,
+            stationId: hubInfo.stationId,
+            typeId,
+            ...(capped && { capped: true }),
+        };
+        await redis.set(cacheKey, JSON.stringify(value), { EX: CACHE_TTL_SEC });
+        return value;
+    } finally {
+        await redis.del(lockKey).catch(() => {});
+    }
+}
+
+/**
+ * 리전 히스토리 기반 평균가(최근 1일/7일). 캐시 TTL 6h.
+ * @param {import("redis").RedisClientType} redis
+ * @param {{ tenantKey: string, regionId: number, typeId: number }} opts
+ * @returns {Promise<{ regionAvg1d: number|null, regionAvg7d: number|null, stale?: boolean }>}
+ */
+export async function getRegionHistory(redis, { tenantKey, regionId, typeId }) {
+    const tenant = String(tenantKey ?? "").trim();
+    const cacheKey = `mkt:${tenant}:esi:history:v1:${regionId}:${typeId}`;
+
+    const cached = await redis.get(cacheKey);
+    if (cached) {
+        try {
+            const data = JSON.parse(cached);
+            return {
+                regionAvg1d: data.regionAvg1d ?? null,
+                regionAvg7d: data.regionAvg7d ?? null,
+            };
+        } catch {
+            // fall through
+        }
+    }
+
+    const fetchHistory = async () => {
+        const res = await fetch(`${ESI_BASE}/markets/${regionId}/history/?type_id=${typeId}`);
+        if (!res.ok) throw new Error(`ESI history 실패: ${res.status}`);
+        const list = await res.json();
+        if (!Array.isArray(list) || list.length === 0) {
+            return { regionAvg1d: null, regionAvg7d: null };
+        }
+        // ESI: date 오름차순 → 마지막이 최신
+        const last7 = list.slice(-7);
+        const last1 = list.slice(-1);
+        const sum7 = last7.reduce((s, e) => s + (Number(e.average) || 0), 0);
+        const avg7 = last7.length ? sum7 / last7.length : null;
+        const avg1 = last1.length ? Number(last1[0].average) || null : null;
+        return { regionAvg1d: avg1, regionAvg7d: avg7 };
+    };
+
+    try {
+        const { regionAvg1d, regionAvg7d } = await runWithLimit(fetchHistory);
+        const value = { regionAvg1d, regionAvg7d };
+        await redis.set(cacheKey, JSON.stringify(value), {
+            EX: HISTORY_CACHE_TTL_SEC,
+        });
+        return value;
+    } catch (err) {
+        const stale = await redis.get(cacheKey);
+        if (stale) {
+            const data = JSON.parse(stale);
+            return {
+                regionAvg1d: data.regionAvg1d ?? null,
+                regionAvg7d: data.regionAvg7d ?? null,
+                stale: true,
+            };
+        }
+        throw err;
+    }
+}
+
+/**
+ * 스테이션 한정 best sell/buy. pageCap=10, 스테이션 오더 발견 후 extraPagesAfterHit만 추가 페이지 후 종료.
+ * @param {number} regionId
+ * @param {number} stationId
+ * @param {number} typeId
+ * @returns {Promise<{ sellMin: number|null, buyMax: number|null, capped?: boolean }>}
+ */
+async function fetchStationOrders(regionId, stationId, typeId) {
+    let sellMin = null;
+    let buyMax = null;
+    let sellPage = 1;
+    let buyPage = 1;
+    let sellHitPage = null;
+    let buyHitPage = null;
+    let sellDone = false;
+    let buyDone = false;
+
+    const shouldFetchSell = () =>
+        !sellDone &&
+        sellPage <= PAGE_CAP &&
+        (sellHitPage == null || sellPage <= sellHitPage + EXTRA_PAGES_AFTER_HIT);
+    const shouldFetchBuy = () =>
+        !buyDone &&
+        buyPage <= PAGE_CAP &&
+        (buyHitPage == null || buyPage <= buyHitPage + EXTRA_PAGES_AFTER_HIT);
+
+    while (shouldFetchSell() || shouldFetchBuy()) {
+        const sellUrl =
+            shouldFetchSell() &&
+            `${ESI_BASE}/markets/${regionId}/orders/?order_type=sell&type_id=${typeId}&page=${sellPage}`;
+        const buyUrl =
+            shouldFetchBuy() &&
+            `${ESI_BASE}/markets/${regionId}/orders/?order_type=buy&type_id=${typeId}&page=${buyPage}`;
+        const [sellRes, buyRes] = await Promise.all([
+            sellUrl ? fetch(sellUrl) : null,
+            buyUrl ? fetch(buyUrl) : null,
+        ]);
+
+        if (sellRes) {
+            if (!sellRes.ok) throw new Error(`ESI 마켓(sell) 실패: ${sellRes.status}`);
+            const sellOrders = await sellRes.json();
+            const sellXPages = parseInt(sellRes.headers.get("x-pages") || "1", 10);
+            for (const o of sellOrders) {
+                if (o.location_id === stationId && typeof o.price === "number") {
+                    if (sellMin == null || o.price < sellMin) sellMin = o.price;
+                    if (sellHitPage == null) sellHitPage = sellPage;
+                }
+            }
+            sellPage++;
+            if (sellPage > sellXPages) sellDone = true;
+            if (sellHitPage != null && sellPage > sellHitPage + EXTRA_PAGES_AFTER_HIT)
+                sellDone = true;
+            if (sellPage > PAGE_CAP) sellDone = true;
+        }
+
+        if (buyRes) {
+            if (!buyRes.ok) throw new Error(`ESI 마켓(buy) 실패: ${buyRes.status}`);
+            const buyOrders = await buyRes.json();
+            const buyXPages = parseInt(buyRes.headers.get("x-pages") || "1", 10);
+            for (const o of buyOrders) {
+                if (o.location_id === stationId && typeof o.price === "number") {
+                    if (buyMax == null || o.price > buyMax) buyMax = o.price;
+                    if (buyHitPage == null) buyHitPage = buyPage;
+                }
+            }
+            buyPage++;
+            if (buyPage > buyXPages) buyDone = true;
+            if (buyHitPage != null && buyPage > buyHitPage + EXTRA_PAGES_AFTER_HIT) buyDone = true;
+            if (buyPage > PAGE_CAP) buyDone = true;
+        }
+    }
+
+    const capped =
+        (sellPage > PAGE_CAP && sellMin == null) || (buyPage > PAGE_CAP && buyMax == null);
+    return { sellMin, buyMax, ...(capped && { capped: true }) };
+}
+
+function sleep(ms) {
+    return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/worker/src/market/esiTypeNameCache.js
+++ b/packages/worker/src/market/esiTypeNameCache.js
@@ -1,0 +1,109 @@
+/**
+ * ESI /universe/types/{type_id}로 타입 표시명 조회 + Redis 장기 캐시.
+ * 캐시 키: typeName:ko:{typeId}, TTL 30일. 한글 요청 실패 시 영어 fallback.
+ * 동시 ESI 호출 수 제한(429 방어).
+ */
+const ESI_BASE = "https://esi.evetech.net/latest";
+const CACHE_KEY_PREFIX = "typeName:ko:";
+const CACHE_TTL_SEC = 30 * 24 * 3600; // 30일
+const ESI_CONCURRENCY = 5;
+
+const queue = [];
+let running = 0;
+
+function runWithLimit(fn) {
+    return new Promise((resolve, reject) => {
+        const run = () => {
+            running++;
+            Promise.resolve(fn())
+                .then(resolve, reject)
+                .finally(() => {
+                    running--;
+                    if (queue.length > 0) queue.shift()();
+                });
+        };
+        if (running < ESI_CONCURRENCY) run();
+        else queue.push(run);
+    });
+}
+
+/**
+ * @param {import("redis").RedisClientType} redis
+ * @param {number} typeId
+ * @returns {Promise<string>} 표시명 (한글 우선, 실패 시 영어)
+ */
+export async function getTypeName(redis, typeId) {
+    const key = `${CACHE_KEY_PREFIX}${typeId}`;
+    const cached = await redis.get(key);
+    if (typeof cached === "string" && cached.trim() !== "") return cached;
+
+    const { name, skipCache } = await runWithLimit(() => fetchTypeName(typeId));
+    const display = typeof name === "string" && name.trim() ? name.trim() : `타입 ${typeId}`;
+    if (!skipCache) {
+        await redis.set(key, display, { EX: CACHE_TTL_SEC });
+    }
+    return display;
+}
+
+/**
+ * 여러 typeId의 표시명을 조회. 캐시된 것은 Redis에서, 나머지는 ESI로 조회 후 캐시.
+ * @param {import("redis").RedisClientType} redis
+ * @param {number[]} typeIds
+ * @returns {Promise<Map<number, string>>} typeId -> name
+ */
+export async function getTypeNames(redis, typeIds) {
+    const unique = [...new Set(typeIds)].filter((id) => Number.isInteger(id) && id > 0);
+    const result = new Map();
+
+    const cacheEntries = await Promise.all(
+        unique.map(async (typeId) => {
+            const key = `${CACHE_KEY_PREFIX}${typeId}`;
+            const cached = await redis.get(key);
+            return { typeId, cached };
+        })
+    );
+
+    const uncached = [];
+    for (const { typeId, cached } of cacheEntries) {
+        const s = typeof cached === "string" ? cached.trim() : "";
+        if (s !== "") {
+            result.set(typeId, cached);
+        } else {
+            uncached.push(typeId);
+        }
+    }
+
+    await Promise.all(
+        uncached.map(async (typeId) => {
+            const name = await getTypeName(redis, typeId);
+            result.set(typeId, name);
+        })
+    );
+
+    return result;
+}
+
+/**
+ * ESI 호출: 한글 요청 후 실패 시 영어 fallback. 404 등 비성공 시 fallback 이름만 반환(캐시 안 함).
+ * @param {number} typeId
+ * @returns {Promise<{ name: string, skipCache: boolean }>}
+ */
+async function fetchTypeName(typeId) {
+    const url = `${ESI_BASE}/universe/types/${typeId}/`;
+    const withLang = (lang) =>
+        fetch(`${url}?language=${lang}`, { headers: { Accept: "application/json" } });
+
+    let res = await withLang("ko");
+    if (!res.ok) {
+        res = await withLang("en");
+    }
+    if (!res.ok) {
+        return { name: `타입 ${typeId}`, skipCache: true };
+    }
+    const data = await res.json();
+    const name = data?.name;
+    if (typeof name !== "string" || !name.trim()) {
+        return { name: `타입 ${typeId}`, skipCache: true };
+    }
+    return { name: name.trim(), skipCache: false };
+}

--- a/packages/worker/tests/commands.index.test.js
+++ b/packages/worker/tests/commands.index.test.js
@@ -12,6 +12,8 @@ describe("worker/commands/index getCommandMap()", () => {
         expect(map.has("가입")).toBe(true);
         expect(map.has("esi-complete")).toBe(true);
         expect(map.has("캐릭터목록")).toBe(true);
+        expect(map.has("가스시세")).toBe(true);
+        expect(map.has("광물시세")).toBe(true);
 
         const ping = map.get("핑");
         expect(typeof ping.execute).toBe("function");
@@ -21,6 +23,6 @@ describe("worker/commands/index getCommandMap()", () => {
         // index.js 내부 add()가 중복을 throw하도록 되어 있어야 함
         // (지금 구조가 이미 그렇다면 이 테스트는 “문서화된 기대치” 역할)
         const map = getCommandMap();
-        expect(map.size).toBeGreaterThanOrEqual(5);
+        expect(map.size).toBeGreaterThanOrEqual(7);
     });
 });


### PR DESCRIPTION
- 시세 명령 3종: /가스시세(Fullerite 9종), /얼음시세(아이스 7종), /광물시세(기본 오어 12종)
- Master: data.embeds 다중 임베드 처리, data.error → ❌ 메시지, 필드 값 1024자 제한
- Prod 브릿지: SNS Message 파싱, guildId 기준 채널 브로드캐스트 제한
- Worker: ESI 마켓 캐시·상수 기반 표시명, 테넌트 DB GRANT 자동 부여
- 토큰/CI: DISCORD_TOKEN 통일, CI는 PR 시에만 실행