### PR TITLE
1.23v

### DIFF
--- a/packages/worker/src/commands/fuel.js
+++ b/packages/worker/src/commands/fuel.js
@@ -133,6 +133,7 @@ export default {
             const displayType = `${buildingType.emoji} ${buildingType.name}`;
             return { name, type: displayType, remainingDays };
         });
+        tableRows.sort((a, b) => (b.name ?? "").localeCompare(a.name ?? "", "ko"));
 
         const nameValue = tableRows.map((r) => r.name).join("\n") || "정보 없음";
         const typeValue = tableRows.map((r) => r.type).join("\n") || "정보 없음";

--- a/packages/worker/src/esi/structureTypeMapping.js
+++ b/packages/worker/src/esi/structureTypeMapping.js
@@ -2,12 +2,16 @@
 // 레거시 fuel/structureFuelAmount.js와 동일
 
 export const structureTypeMapping = {
-    35832: { name: "허스", emoji: "<:Citadel_Astrahus:1469750432879345804>" },
-    35833: { name: "포티자", emoji: "<:Citadel_Fortizar:1469750434309738689>" },
-    35834: { name: "킵스타", emoji: "<:Citadel_Keepstar:1469751292577710141>" },
-    35825: { name: "라이따루", emoji: "<:Engineering_Raitaru:1469750436490772713>" },
-    35826: { name: "아즈벨", emoji: "<:Engineering_Azbel:1469750442929033286>" },
-    35827: { name: "소티요", emoji: "<:Engineering_Sotiyo:1469750437967171624>" },
-    35835: { name: "아싸노", emoji: "<:Refinery_Athanor:1469750439489830912>" },
-    35836: { name: "타타라", emoji: "<:Refinery_Tatara:1469750441092059187>" },
+    35832: { name: "허스", emoji: "<:Astrahus:1469750432879345804>" },
+    35833: { name: "포티자", emoji: "<:Fortizar:1469750434309738689>" },
+    35834: { name: "킵스타", emoji: "<:Keepstar:1469751292577710141>" },
+    35825: { name: "라이따루", emoji: "<:Raitaru:1469750436490772713>" },
+    35826: { name: "아즈벨", emoji: "<:Azbel:1469750442929033286>" },
+    35827: { name: "소티요", emoji: "<:Sotiyo:1469750437967171624>" },
+    35835: { name: "아싸노", emoji: "<:Athanor:1469750439489830912>" },
+    35836: { name: "타타라", emoji: "<:Tatara:1469750441092059187>" },
+    35840: { name: "패롤럭스 사이노 비컨", emoji: "<:Cyno_Beacon:1470047199613157538>" },
+    37534: { name: "테네브렉스 사이노 재머", emoji: "<:Cyno_Jammer:1470047239450791998>" },
+    81826: { name: "메테녹스 위성 드릴", emoji: "<:Moon_Drill:1470047303913177183>" },
+    35841: { name: "안시블렉스 점프 브릿지", emoji: "<:Ansiblex:1470047361488388229>" },
 };


### PR DESCRIPTION
빠진 건물 유형 추가

    35840: { name: "패롤럭스 사이노 비컨", emoji: "<:Cyno_Beacon:1470047199613157538>" },
    37534: { name: "테네브렉스 사이노 재머", emoji: "<:Cyno_Jammer:1470047239450791998>" },
    81826: { name: "메테녹스 위성 드릴", emoji: "<:Moon_Drill:1470047303913177183>" },
    35841: { name: "안시블렉스 점프 브릿지", emoji: "<:Ansiblex:1470047361488388229>" },
    
  이모지 길이 짧게 단순화